### PR TITLE
Fix deployment type error

### DIFF
--- a/app/api/requests/[id]/route.ts
+++ b/app/api/requests/[id]/route.ts
@@ -15,8 +15,11 @@ interface CompletedTask {
   completedAt: string; // ISO date string
 }
 
-export async function PUT(request: NextRequest, { params }: { params: { id: string } }) {
-  const { id } = params; // Request ID from the URL path
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params; // Await the params promise
 
   if (!id) {
     return NextResponse.json({ error: 'Request ID is required' }, { status: 400 });
@@ -109,8 +112,12 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
 }
 
 // Basic GET handler for testing purposes (optional)
-export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
-  const { id } = params;
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const { id } = await params; // Await the params promise
+  
   if (!id) {
     return NextResponse.json({ error: 'Request ID is required' }, { status: 400 });
   }


### PR DESCRIPTION
Fix Next.js 15 API route type error by awaiting dynamic route parameters.

Next.js 15 introduced a breaking change where dynamic route parameters are now wrapped in a Promise, causing a type error during compilation if not awaited. This PR updates the `GET` and `PUT` handlers in `app/api/requests/[id]/route.ts` to correctly handle these parameters.