### PR TITLE
Fix TypeScript errors in user fields

### DIFF
--- a/app/(authenticated)/dashboard/page.tsx
+++ b/app/(authenticated)/dashboard/page.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
 import { FileText, CheckCircle, Clock, ArrowRight } from 'lucide-react'
 import { getUserPackageProgress, PackageProgress } from '@/lib/package-utils'
+import ErrorBoundary from '@/components/error-boundary'
 
 export default async function DashboardPage() {
   const session = await auth()
@@ -46,9 +47,6 @@ export default async function DashboardPage() {
     const tasksSubtitle = packageProgress
       ? `${tasksCompletedThisMonth} of ${tasksTotalThisMonth} used this month`
       : "No active package"
-
-    // Import ErrorBoundary
-    const ErrorBoundary = (await import('@/components/error-boundary')).default;
 
     return (
       <ErrorBoundary>

--- a/build-fix-summary.md
+++ b/build-fix-summary.md
@@ -1,0 +1,65 @@
+# Build Fix Summary
+
+## Issues Resolved
+
+### 1. TypeScript Errors in `scripts/fix-user-fields.ts`
+
+**Problem**: The script was using `null` in Prisma where clauses, which is incompatible with non-nullable field types.
+
+**Solution**: 
+- Removed the where clause filtering since the fields have default values in the Prisma schema
+- Changed approach to fetch all users and check for missing values in the loop
+- This ensures compatibility with Prisma's type system
+
+### 2. ErrorBoundary Import Error in `app/(authenticated)/dashboard/page.tsx`
+
+**Problem**: ErrorBoundary was being dynamically imported inside an async Server Component, causing a "Cannot find name" error.
+
+**Solution**: 
+- Moved the ErrorBoundary import to the top of the file with other imports
+- Since ErrorBoundary is a client component, it can be imported normally in Server Components
+
+## Recommendations to Prevent Future Issues
+
+### 1. Type Safety with Prisma
+
+- When querying with Prisma, remember that fields with default values in the schema are non-nullable
+- Use proper Prisma filter operators for nullable fields (e.g., `{ field: { equals: null } }` for nullable fields)
+- For non-nullable fields with defaults, check values after fetching rather than in the where clause
+
+### 2. Component Imports
+
+- Import client components at the top of Server Components files
+- Avoid dynamic imports inside Server Components unless necessary for code splitting
+- Use static imports for components that are always needed
+
+### 3. Build Testing
+
+- Always run `npm run type-check` before deploying to catch TypeScript errors early
+- Consider adding a pre-commit hook to run type checking
+- Set up CI/CD to run type checks on pull requests
+
+### 4. Script Best Practices
+
+- When writing database migration scripts:
+  - Handle edge cases where data might be in unexpected states
+  - Use proper type guards when checking for null/undefined values
+  - Add proper error handling and logging
+  - Test scripts locally before deploying
+
+### 5. Environment Variables
+
+- The build will fail if required environment variables are missing
+- Ensure all required variables are set in your deployment environment:
+  - `DATABASE_URL`
+  - `NEXTAUTH_URL`
+  - `NEXTAUTH_SECRET`
+  - `ENCRYPTION_KEY`
+
+## Type Error Prevention Checklist
+
+- [ ] Run `npm run type-check` before commits
+- [ ] Review Prisma schema for field nullability before writing queries
+- [ ] Import all components at the top of files
+- [ ] Test scripts with edge cases before deployment
+- [ ] Ensure environment variables are properly configured

--- a/scripts/fix-user-fields.ts
+++ b/scripts/fix-user-fields.ts
@@ -5,21 +5,12 @@ async function fixUserFields() {
   console.log('Starting user fields fix...')
   
   try {
-    // Find all users missing required fields
-    const users = await prisma.user.findMany({
-      where: {
-        OR: [
-          { role: null },
-          { onboardingCompleted: null },
-          { pagesUsedThisPeriod: null },
-          { blogsUsedThisPeriod: null },
-          { gbpPostsUsedThisPeriod: null },
-          { improvementsUsedThisPeriod: null },
-        ]
-      }
-    })
+    // Find all users and check for missing fields
+    const users = await prisma.user.findMany()
     
-    console.log(`Found ${users.length} users with missing fields`)
+    console.log(`Checking ${users.length} users for missing fields`)
+    
+    let updatedCount = 0
     
     // Update each user with default values
     for (const user of users) {
@@ -50,10 +41,11 @@ async function fixUserFields() {
           data: updateData
         })
         console.log(`Updated user ${user.email} with:`, updateData)
+        updatedCount++
       }
     }
     
-    console.log('User fields fix completed!')
+    console.log(`User fields fix completed! Updated ${updatedCount} users.`)
   } catch (error) {
     console.error('Error fixing user fields:', error)
     process.exit(1)


### PR DESCRIPTION
Fix TypeScript build errors by correcting Prisma queries for non-nullable fields and ensuring static component imports in Server Components.

The `fix-user-fields.ts` script was attempting to filter users by `null` values in fields that are defined as non-nullable in the Prisma schema (due to default values), leading to TypeScript errors. The solution is to fetch all users and then programmatically check for and patch missing/default values. Additionally, a dynamic import of `ErrorBoundary` in a Server Component was causing a build error, which was resolved by a static import at the top of the file.